### PR TITLE
Better logging (masking passwords)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ IGNORE
 
 # Virtualenv
 /venv
+venv*
+

--- a/esgfpid/rabbit/nodemanager.py
+++ b/esgfpid/rabbit/nodemanager.py
@@ -532,7 +532,7 @@ class NodeManager(object):
             where_to_look = self.__trusted_nodes_archive
 
         if not type(where_to_look) == type(dict()):
-            raise ValueError('%s is not a dict!')
+            raise ValueError('%s is not a dict!' % where_to_look)
 
         for prio, nodes in where_to_look.items():
             for candidate in nodes:

--- a/esgfpid/utils/logutils.py
+++ b/esgfpid/utils/logutils.py
@@ -1,4 +1,5 @@
 import esgfpid.defaults
+import copy
 
 #
 # Logging helpers

--- a/esgfpid/utils/logutils.py
+++ b/esgfpid/utils/logutils.py
@@ -52,3 +52,29 @@ def log_every_x_times(logger, counter, x, msg, *args, **kwargs):
     if counter==1 or counter % x == 0:
         #msg = msg + (' (counter %i)' % counter)
         logdebug(logger, msg, *args, **kwargs)
+
+def make_logsafe(list_or_dict, forbidden='password'):
+    if not forbidden in str(list_or_dict):
+        return list_or_dict
+
+    # don't modify the original:
+    logsafe = copy.deepcopy(list_or_dict)
+
+    # Dict (only first level):
+    # TODO: Recursively check deeper levels, or count occurrences of 
+    # forbidden word to make sure you got them all.
+    try:
+        logsafe[forbidden] = logsafe[forbidden][0:3]+'...'
+    except KeyError:
+        pass
+    except TypeError:
+
+        # List of dicts (only first level):
+        for item in logsafe:
+            try:
+                item[forbidden] = item[forbidden][0:3]+'...'
+            except KeyError:
+                pass
+
+    return logsafe
+

--- a/tests/testcases/rabbit/nodemanager_tests.py
+++ b/tests/testcases/rabbit/nodemanager_tests.py
@@ -640,6 +640,27 @@ class NodemanagerTestCase(unittest.TestCase):
         self.assertEqual(new_prio, 'zzzz_last',   'Prio after changing prio is %s, expected zzzz_last' % new_prio)
 
 
+
+    '''
+    Test setting the priority to the lowest value, once.
+    Check if the password is masked from log output.
+    '''
+    def test_change_prio_pw_masking(self):
+
+        # Test variables:
+        mynodemanager = esgfpid.rabbit.nodemanager.NodeManager()
+        mynodemanager.add_trusted_node(**TESTHELPERS.get_args_for_nodemanager())
+        mynodemanager.set_next_host()
+
+        # Run code to be tested:
+        with self.assertLogs() as context_manager:
+            mynodemanager.set_priority_low_for_current()
+
+        # Check result
+        self.assertTrue('pw_foo' not in str(context_manager.output), 'Password (pw_foo) is not masked: %s' % context_manager.output)
+        self.assertTrue('pw_' in str(context_manager.output), 'Masked password stub (pw_f) missing: %s' % context_manager.output)
+
+
     '''
     Test setting the priority to the lowest value, twice.
     This tests whether the function can handle nodes that "already"
@@ -692,3 +713,4 @@ class NodemanagerTestCase(unittest.TestCase):
         self.assertEqual(old_prio, 'dummy_prio', 'Default prio is %s, expected dummy_prio' % old_prio)
         self.assertEqual(new_prio1, 'zzzz_last',  'Prio after changing prio is %s, expected zzzz_last' % new_prio1)
         self.assertEqual(new_prio2, 'zzzz_last',  'Prio after changing prio is %s, expected zzzz_last' % new_prio2)
+

--- a/tests/testcases/rabbit/nodemanager_tests.py
+++ b/tests/testcases/rabbit/nodemanager_tests.py
@@ -162,6 +162,25 @@ class NodemanagerTestCase(unittest.TestCase):
             mynodemanager.add_trusted_node(username='foo', exchange_name='bar')
 
     '''
+    Test exception if I miss info, and check if password is printed
+    (it should not!)
+    '''
+    def test_add_nodes_missing_info_2(self):
+
+        # Test variables:
+        # Make test node manager:
+        mynodemanager = esgfpid.rabbit.nodemanager.NodeManager()
+
+        # Run code to be tested and check exception:
+        with self.assertRaises(esgfpid.exceptions.ArgumentError) as context_manager:
+            mynodemanager.add_trusted_node(username='foo', exchange_name='bar',
+                password='einekleinenachtmusik')
+
+        # Check exception content:
+        ex = context_manager.exception
+        self.assertTrue('einekleinenachtmusik' not in ex.msg, ex)
+
+    '''
     Test exception if I miss info
     '''
     @unittest.skipIf(globalvar.RABBIT_OPEN_NOT_ALLOWED, '(this test uses open rabbit nodes)')

--- a/tests/testcases/util_logging_tests.py
+++ b/tests/testcases/util_logging_tests.py
@@ -241,3 +241,39 @@ class UtilsLoggingTestCase(unittest.TestCase):
         expected_messages = 'Foobar1, Foobar10, Foobar20, Foobar30'
         self.assertEqual([],logger.info_messages,'Received info messages: "%s" (should be empty list).' % logger.info_messages)
         self.assertEqual(expected_messages, received_messages, 'Received messages: %s (should be %s).' % (received_messages,expected_messages))
+
+
+    def test_make_logsafe_list_normal(self):
+        input_list = [{'a':'aaa', 'b':'bbb', 'password':'einekleinenachtmusik'},
+                      {'a':'111', 'b':'222', 'c':'333'}]
+        output = make_logsafe(input_list)
+        self.assertTrue('password' not in str(output))
+
+    def test_make_logsafe_list_several(self):
+        input_list = [{'a':'aaa', 'b':'bbb', 'password':'einekleinenachtmusik'},
+                      {'a':'111', 'b':'222', 'password':'unpetitemusique'}]
+        output = make_logsafe(input_list)
+        self.assertTrue('password' not in str(output))
+    
+    def test_make_logsafe_list_none(self):
+        input_list = [{'a':'aaa', 'b':'bbb', 'c':'einekleinenachtmusik'},
+                      {'a':'111', 'b':'222', 'c':'unpetitemusique'}]
+        output = make_logsafe(input_list)
+        self.assertTrue('password' not in str(output))
+        self.assertEqual(input_list, output)
+
+    def test_make_logsafe_list_differentword(self):
+        input_list = [{'a':'aaa', 'b':'bbb', 'c':'einekleinenachtmusik'},
+                      {'a':'111', 'b':'222', 'motdepasse':'unpetitemusique'}]
+        output = make_logsafe(input_list, 'motdepasse')
+        self.assertTrue('password' not in str(output))
+
+    def test_make_logsafe_dict_normal(self):
+        input_dict = {'a':'aaa', 'b':'bbb', 'password':'einekleinenachtmusik'}
+        output = make_logsafe(input_dict)
+        self.assertTrue('password' not in str(output))
+
+    def test_make_logsafe_dict_differentword(self):
+        input_dict = {'a':'aaa', 'b':'bbb', 'motdepasse':'einekleinenachtmusik'}
+        output = make_logsafe(input_dict, 'motdepasse')
+        self.assertTrue('password' not in str(output))

--- a/tests/testcases/util_logging_tests.py
+++ b/tests/testcases/util_logging_tests.py
@@ -260,15 +260,12 @@ class UtilsLoggingTestCase(unittest.TestCase):
         input_list = [{'a':'aaa', 'b':'bbb', 'c':'einekleinenachtmusik'},
                       {'a':'111', 'b':'222', 'c':'unpetitemusique'}]
         output = esgfpid.utils.make_logsafe(input_list)
-        self.assertTrue('einekleinenachtmusik' not in str(output))
-        self.assertTrue('unpetitemusique' not in str(output))
         self.assertEqual(input_list, output)
 
     def test_make_logsafe_list_differentword(self):
         input_list = [{'a':'aaa', 'b':'bbb', 'c':'einekleinenachtmusik'},
                       {'a':'111', 'b':'222', 'motdepasse':'unpetitemusique'}]
         output = esgfpid.utils.make_logsafe(input_list, 'motdepasse')
-        self.assertTrue('einekleinenachtmusik' not in str(output))
         self.assertTrue('unpetitemusique' not in str(output))
 
     def test_make_logsafe_dict_normal(self):

--- a/tests/testcases/util_logging_tests.py
+++ b/tests/testcases/util_logging_tests.py
@@ -246,34 +246,43 @@ class UtilsLoggingTestCase(unittest.TestCase):
     def test_make_logsafe_list_normal(self):
         input_list = [{'a':'aaa', 'b':'bbb', 'password':'einekleinenachtmusik'},
                       {'a':'111', 'b':'222', 'c':'333'}]
-        output = make_logsafe(input_list)
-        self.assertTrue('password' not in str(output))
+        output = esgfpid.utils.make_logsafe(input_list)
+        self.assertTrue('einekleinenachtmusik' not in str(output))
 
     def test_make_logsafe_list_several(self):
         input_list = [{'a':'aaa', 'b':'bbb', 'password':'einekleinenachtmusik'},
                       {'a':'111', 'b':'222', 'password':'unpetitemusique'}]
-        output = make_logsafe(input_list)
-        self.assertTrue('password' not in str(output))
+        output = esgfpid.utils.make_logsafe(input_list)
+        self.assertTrue('einekleinenachtmusik' not in str(output))
+        self.assertTrue('unpetitemusique' not in str(output))
     
     def test_make_logsafe_list_none(self):
         input_list = [{'a':'aaa', 'b':'bbb', 'c':'einekleinenachtmusik'},
                       {'a':'111', 'b':'222', 'c':'unpetitemusique'}]
-        output = make_logsafe(input_list)
-        self.assertTrue('password' not in str(output))
+        output = esgfpid.utils.make_logsafe(input_list)
+        self.assertTrue('einekleinenachtmusik' not in str(output))
+        self.assertTrue('unpetitemusique' not in str(output))
         self.assertEqual(input_list, output)
 
     def test_make_logsafe_list_differentword(self):
         input_list = [{'a':'aaa', 'b':'bbb', 'c':'einekleinenachtmusik'},
                       {'a':'111', 'b':'222', 'motdepasse':'unpetitemusique'}]
-        output = make_logsafe(input_list, 'motdepasse')
-        self.assertTrue('password' not in str(output))
+        output = esgfpid.utils.make_logsafe(input_list, 'motdepasse')
+        self.assertTrue('einekleinenachtmusik' not in str(output))
+        self.assertTrue('unpetitemusique' not in str(output))
 
     def test_make_logsafe_dict_normal(self):
         input_dict = {'a':'aaa', 'b':'bbb', 'password':'einekleinenachtmusik'}
-        output = make_logsafe(input_dict)
-        self.assertTrue('password' not in str(output))
+        output = esgfpid.utils.make_logsafe(input_dict)
+        self.assertTrue('einekleinenachtmusik' not in str(output))
+
+    def test_make_logsafe_dict_several(self):
+        input_dict = {'a':'aaa', 'password':'maismusica', 'password':'einekleinenachtmusik'}
+        output = esgfpid.utils.make_logsafe(input_dict)
+        self.assertTrue('einekleinenachtmusik' not in str(output))
+        self.assertTrue('maismusica' not in str(output))
 
     def test_make_logsafe_dict_differentword(self):
         input_dict = {'a':'aaa', 'b':'bbb', 'motdepasse':'einekleinenachtmusik'}
-        output = make_logsafe(input_dict, 'motdepasse')
-        self.assertTrue('password' not in str(output))
+        output = esgfpid.utils.esgfpid.utils.make_logsafe(input_dict, 'motdepasse')
+        self.assertTrue('einekleinenachtmusik' not in str(output))


### PR DESCRIPTION
I added an util to the logging utils that allows to remove passwords before logging, and applied it to all places in nodemanager.py where node info is logged.
The util function is unit tested. In two of five occurrences in nodemanager.py, I test whether the password is really properly removed. Tested in python 3.6.